### PR TITLE
Clean up build.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,4 @@ members = ["bench"]
 debug = true
 
 [build-dependencies]
-lazy_static = "1.4.0"
-maplit = "1.0.2"
 phf_codegen = "0.8.0"

--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,7 @@ fn byte_to_emoji(value: u8) -> String {
     let mut value = value;
 
     if value == 0 {
-        return "❤️".to_string();
+        buffer.push_str("❤️");
     }
 
     loop {

--- a/src/bottom.rs
+++ b/src/bottom.rs
@@ -119,4 +119,17 @@ mod tests {
             "がんばれ",
         );
     }
+
+    #[test]
+    fn test_embedded_null_byte() {
+        assert_eq!(
+            encode_string(&"\0"),
+            "❤️👉👈",
+        );
+        assert_eq!(
+            decode_string(&"❤️👉👈")
+                .unwrap(),
+            "\0",
+        );
+    }
 }


### PR DESCRIPTION
Hiiii, i know there's already #6 but i just find the `build.rs` super overcomplicated even with that. This PR removes `lazy_static` and `maplit` dependencies and the `unsafe` in favour of less code and possibly teeeny tiny improvement in build speed, though the priority really was just to make the code clearer. Only sad thing is it gets rid of the funny safety comment, sorrry 🥺